### PR TITLE
Fix: Resolve module not found errors and build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
+    "react-hot-toast": "^2.4.1",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
@@ -91,5 +92,13 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "esbuild",
+      "protobufjs",
+      "sharp"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       react-hook-form:
         specifier: ^7.54.2
         version: 7.56.3(react@18.3.1)
+      react-hot-toast:
+        specifier: ^2.4.1
+        version: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.15.1
         version: 2.15.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3809,6 +3812,11 @@ packages:
     resolution: {integrity: sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==}
     engines: {node: '>=0.10.0'}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
@@ -5032,6 +5040,13 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-hot-toast@2.5.2:
+    resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -10370,6 +10385,10 @@ snapshots:
       pify: 2.3.0
       pinkie-promise: 2.0.1
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -11828,6 +11847,13 @@ snapshots:
   react-hook-form@7.56.3(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  react-hot-toast@2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 

--- a/src/app/admin/addition-requests/page.tsx
+++ b/src/app/admin/addition-requests/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { db } from '@/lib/firebase'; // Assuming client-side firebase is configured
+import { db } from '@/lib/firebaseClient'; // Assuming client-side firebase is configured
 import { collection, query, where, getDocs, doc, updateDoc, serverTimestamp, Timestamp } from 'firebase/firestore';
-import { useAuth } from '@/contexts/AuthContext'; // Assuming an AuthContext provides user and role
+import { useAuth } from '@/hooks/useAuth'; // Assuming an AuthContext provides user and role
 import { toast } from 'react-hot-toast';
 import styles from '@/styles/AdminRequests.module.css'; // Reusing styles from removal requests page
 


### PR DESCRIPTION
This commit addresses several "Module not found" errors and a pnpm build script warning that were causing the Vercel build to fail.

Changes include:
- Corrected import paths in `src/app/admin/addition-requests/page.tsx`:
    - Changed `db` import from `'@/lib/firebase'` to `'@/lib/firebaseClient'`.
    - Changed `useAuth` import from `'@/contexts/AuthContext'` to `'@/hooks/useAuth'`.
- Created `src/styles/AdminRequests.module.css` as an empty file to satisfy a missing import.
- Added `react-hot-toast` to `package.json` dependencies and ran `pnpm install` to update the lockfile.
- Addressed pnpm build warnings by specifying `onlyBuiltDependencies` in `package.json` to allow scripts for `@firebase/util`, `esbuild`, `protobufjs`, and `sharp`.