### PR TITLE
Reduce duplication in API routes

### DIFF
--- a/src/app/api/admin/make-admin/route.ts
+++ b/src/app/api/admin/make-admin/route.ts
@@ -1,20 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, adminAuth } from '@/lib/firebaseAdmin';
+import { getUserUid } from '@/lib/auth';
 import { FieldValue } from 'firebase-admin/firestore';
 
 // This endpoint should only be accessible to super administrators
 export async function POST(request: NextRequest) {
   try {
     // Get session cookie for authorization
-    const sessionCookie = request.cookies.get('session')?.value;
-    
-    if (!sessionCookie) {
+    const requestingUserUid = await getUserUid(request);
+    if (!requestingUserUid) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
-
-    // Verify session and user identity
-    const decodedClaims = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const requestingUserUid = decodedClaims.uid;
     
     // Security check: Verify that the requesting user is THE Master Admin
     const masterAdminEnvUid = process.env.MASTER_ADMIN_UID;

--- a/src/app/api/admin/revoke-admin/route.ts
+++ b/src/app/api/admin/revoke-admin/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, NextRequest } from "next/server";
 import { adminAuth, db } from "@/lib/firebaseAdmin";
+import { getUserUid } from '@/lib/auth';
 import { FieldValue } from 'firebase-admin/firestore';
 
 export const runtime = "nodejs";
@@ -14,13 +15,10 @@ export async function POST(req: NextRequest) {
 
   try {
     // 1. Verify session cookie and get caller's UID
-    const sessionCookie = req.cookies.get("session")?.value;
-    if (!sessionCookie) {
+    const callerUid = await getUserUid(req);
+    if (!callerUid) {
       return NextResponse.json({ error: "Unauthorized: No session cookie" }, { status: 401 });
     }
-
-    const decodedToken = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const callerUid = decodedToken.uid;
 
     // 2. Check if the caller is the Master Admin
     if (callerUid !== masterAdminUid) {

--- a/src/app/api/auth/verify-admin/route.ts
+++ b/src/app/api/auth/verify-admin/route.ts
@@ -1,18 +1,13 @@
 import { NextRequest } from 'next/server';
 import { adminAuth, db } from '@/lib/firebaseAdmin';
+import { getUserUid } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
   try {
-    // Get session cookie
-    const sessionCookie = request.cookies.get('session')?.value;
-    
-    if (!sessionCookie) {
+    const uid = await getUserUid(request);
+    if (!uid) {
       return Response.json({ error: 'No session cookie provided' }, { status: 401 });
     }
-
-    // Verify session
-    const decodedClaims = await adminAuth.verifySessionCookie(sessionCookie);
-    const uid = decodedClaims.uid;
 
     // Get user document from Firestore to check role
     const userDoc = await db.collection('users').doc(uid).get();

--- a/src/app/api/inventory/[id]/route.ts
+++ b/src/app/api/inventory/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, adminAuth } from '@/lib/firebaseAdmin';
+import { db } from '@/lib/firebaseAdmin';
+import { getUserUid } from '@/lib/auth';
 import { FieldValue } from 'firebase-admin/firestore';
 import type { InventoryItemData } from '@/types/inventory';
 import type { ChangeLogEntry } from '@/types/changeLog';
@@ -19,14 +20,9 @@ export async function GET(
 ) {
   try {
     const { id } = await params; // <- await añadido
-    
-    const token = req.cookies.get('session')?.value;
-    if (!token) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    try {
-      await adminAuth.verifySessionCookie(token, true);
-    } catch (error) {
+
+    const uid = await getUserUid(req);
+    if (!uid) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
@@ -55,15 +51,9 @@ export async function PATCH(
 ) {
   try {
     const { id } = await params; // <- await añadido
-    
-    const token = req.cookies.get('session')?.value;
-    if (!token) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    let uid: string;
-    try {
-      ({ uid } = await adminAuth.verifySessionCookie(token, true));
-    } catch (err) {
+
+    const uid = await getUserUid(req);
+    if (!uid) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -152,18 +142,9 @@ export async function DELETE(
     const { id } = await params; // <- await añadido
     console.log('DELETE request started for item:', id);
     
-    const token = req.cookies.get('session')?.value;
-    if (!token) {
+    const uid = await getUserUid(req);
+    if (!uid) {
       console.log('No token found in cookies');
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-    
-    let uid: string;
-    try {
-      ({ uid } = await adminAuth.verifySessionCookie(token, true));
-      console.log('Token verified, uid:', uid);
-    } catch (err) {
-      console.error('Token verification failed:', err);
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
   

--- a/src/app/api/inventory/request-addition/route.ts
+++ b/src/app/api/inventory/request-addition/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { db, adminAuth } from '@/lib/firebaseAdmin';
+import { db } from '@/lib/firebaseAdmin';
+import { getUserUid } from '@/lib/auth';
 import { FieldValue } from 'firebase-admin/firestore';
 
 export const runtime = 'nodejs';
@@ -7,14 +8,10 @@ export const runtime = 'nodejs';
 export async function POST(req: NextRequest) {
   try {
     // 1. Get session cookie and verify authentication
-    const sessionCookie = req.cookies.get('session')?.value;
-    if (!sessionCookie) {
+    const uid = await getUserUid(req);
+    if (!uid) {
       return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
     }
-
-    // 2. Verify the session cookie and get the user
-    const decodedClaims = await adminAuth.verifySessionCookie(sessionCookie, true);
-    const uid = decodedClaims.uid;
 
     // 3. Parse the request body
     const body = await req.json();

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from 'next/server';
+import { adminAuth } from './firebaseAdmin';
+
+/**
+ * Retrieves the authenticated user's UID from the request using the
+ * Firebase session cookie. Returns `null` if the cookie is missing or
+ * invalid.
+ */
+export async function getUserUid(req: NextRequest | Request): Promise<string | null> {
+  const token = 'cookies' in req
+    ? req.cookies.get('session')?.value
+    : req.headers.get('cookie')?.match(/session=([^;]+)/)?.[1];
+
+  if (!token) {
+    return null;
+  }
+
+  try {
+    const { uid } = await adminAuth.verifySessionCookie(token, true);
+    return uid;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- centralize session cookie verification in `src/lib/auth.ts`
- apply helper to auth/inventory/admin API routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c8a8088832c917536acbc79c8d5